### PR TITLE
Rename mdast to remark

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,11 +77,11 @@ function formatType(node, getNamedLink) {
 
   case Syntax.TypeApplication:
     return formatType(node.expression, getNamedLink)
-      .concat(commaList(getNamedLink, node.applications, '.&lt;', '&gt;'));
+      .concat(commaList(getNamedLink, node.applications, '.<', '>'));
   case Syntax.UnionType:
     return commaList(getNamedLink, node.elements, '(', ')', '|');
   case Syntax.ArrayType:
-    return commaList(getNamedLink, node.elements, '&#91;', '&#93;');
+    return commaList(getNamedLink, node.elements, '[', ']');
   case Syntax.RecordType:
     return commaList(getNamedLink, node.fields, '{', '}');
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "unist-builder": "^1.0.0"
   },
   "devDependencies": {
-    "mdast": "^2.3.0",
+    "remark": "^3.0.0",
     "tap": "^2.3.1"
   }
 }

--- a/test/format_type.js
+++ b/test/format_type.js
@@ -2,7 +2,7 @@
 'use strict';
 
 var formatType = require('../index').formatType,
-  mdast = require('mdast'),
+  remark = require('remark'),
   parse = require('doctrine').parse,
   test = require('tap').test;
 
@@ -12,8 +12,8 @@ test('formatType', function (t) {
     ['null', 'null'],
     ['null', 'null'],
     ['*', 'Any'],
-    ['Array|undefined', '([Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)|[undefined](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined))'],
-    ['Array<number>', '[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array).&lt;[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)&gt;'],
+    ['Array|undefined', '([Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array)\\|[undefined](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined))'],
+    ['Array<number>', '[Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array).&lt;[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)>'],
     ['number!', '[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)!'],
     ['function(string, boolean)', 'function ([string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String), [boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean))'],
     ['function(string, boolean): number', 'function ([string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String), [boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)): [number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)'],
@@ -21,7 +21,7 @@ test('formatType', function (t) {
     ['function(this:something, string)', 'function (this: something, [string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String))'],
     ['function(new:something)', 'function (new: something)'],
     ['{myNum: number, myObject}', '{myNum: [number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number), myObject}'],
-    ['[string,]', '&#91;[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)&#93;'],
+    ['[string,]', '\\[[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)]'],
     ['number?', '[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)?'],
     ['?number', '?[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)'],
     ['?', '?'],
@@ -32,14 +32,14 @@ test('formatType', function (t) {
     ['...number', '...[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)'],
     ['undefined', '[undefined](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined)']
   ].forEach(function (example) {
-    t.deepEqual(mdast().stringify({
+    t.deepEqual(remark().stringify({
       type: 'paragraph',
       children: formatType(
           parse('@param {' + example[0] + '} a', { sloppy: true }).tags[0].type)
     }), example[1], example[0]);
   });
 
-  t.deepEqual(mdast().stringify({
+  t.deepEqual(remark().stringify({
     type: 'paragraph',
     children: formatType(
         parse('@param {number} [a=1]', { sloppy: true }).tags[0].type)


### PR DESCRIPTION
This additionally updates remark, which includes AST-escaping,
resulting in no unnecessary escapes inside documentation.

This PR ensures documentationjs/documentation#322 will pass.
