### PR TITLE
Support string and number literal types

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,6 +79,8 @@ function formatType(node, getHref) {
     return [t('null')];
   case Syntax.VoidLiteral:
     return [t('void')];
+  case 'StringLiteral': // Does not appear to be exported in doctrine.Syntax
+    return [t(JSON.stringify(node.name))];
   case Syntax.UndefinedLiteral:
     return [link('undefined', getHref)];
   case Syntax.NameExpression:

--- a/index.js
+++ b/index.js
@@ -81,6 +81,8 @@ function formatType(node, getHref) {
     return [t('void')];
   case 'StringLiteral': // Does not appear to be exported in doctrine.Syntax
     return [t(JSON.stringify(node.name))];
+  case 'NumberLiteral': // Does not appear to be exported in doctrine.Syntax
+    return [t(JSON.stringify(node.name))];
   case Syntax.UndefinedLiteral:
     return [link('undefined', getHref)];
   case Syntax.NameExpression:


### PR DESCRIPTION
This fixes breakage I've seen when trying to generate HTML documentation from Flow types that contain literal types as their members, (e.g. member types of [disjoint unions](http://flowtype.org/blog/2015/07/03/Disjoint-Unions.html)). String and number literals are both supported to match Flow. (Possibly booleans are also needed? The Flow changelog hints at this)

I couldn't figure out how to add proper tests, unfortunately, but the minimal case that used to cause errors is running `documentation build --format html` on the following two variations of the same code:

``` javascript
/**
 * A
 */
type A = {tag: 'A';};
```

``` javascript
/**
 * A
 */
type A = {tag: 1;};
```
